### PR TITLE
fixed typo in scaledAccuracy. predcted->predicted

### DIFF
--- a/verify/__init__.py
+++ b/verify/__init__.py
@@ -373,7 +373,7 @@ def scaledAccuracy(predicted, observed):
                'MdSymAcc': medSymAccuracy}
     out = dict()
     for met in metrics:
-        out[met] = metrics[met](predcted, observed)
+        out[met] = metrics[met](predicted, observed)
 
     return out
 


### PR DESCRIPTION
There was a typo in the variable name. Could not have worked before. 